### PR TITLE
Allow FetchContent Usage via Brew 

### DIFF
--- a/Formula/jank.rb
+++ b/Formula/jank.rb
@@ -39,7 +39,8 @@ class Jank < Formula
 
     system "./bin/configure",
            "-GNinja",
-           *std_cmake_args
+           *std_cmake_args,
+           "-DHOMEBREW_ALLOW_FETCHCONTENT=ON"
     system "./bin/compile"
     system "./bin/install"
   end


### PR DESCRIPTION
This PR adds the `-DHOMEBREW_ALLOW_FETCHCONTENT=ON` flag to enable FetchContent during `brew install`.

Homebrew issue discussion linked [here.](https://github.com/Homebrew/brew/issues/17187)

There's likely another solution through CMake changes in the main project, but this offers another fix.

## Issue:

Running `brew install jank-lang/jank/jank` encounters FetchContent error:
```bash
==> Installing jank-lang/jank/jank
/opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.3.7/lib/ruby/3.3.0/fileuti
ls.rb:240: warning: conflicting chdir during another chdir block
==> ./bin/configure -GNinja -DCMAKE_INSTALL_PREFIX=/opt/homebrew/Cellar/jank/0.1
Last 15 lines from /Users/joey.drew/Library/Logs/Homebrew/jank/01.configure:
-- Performing Test HAS_MACH_VM - Success
-- Cpptrace auto config: Using execinfo.h for unwinding
-- Cpptrace auto config: Using libdwarf for symbols
-- Cpptrace auto config: Using cxxabi for demangling
CMake Error at /opt/homebrew/Library/Homebrew/cmake/trap_fetchcontent_provider.c
make:12 (message):
  Refusing to populate dependency 'zstd' with FetchContent while building in
  Homebrew, please use a formula dependency or add a resource to the formula.
Call Stack (most recent call first):
  /opt/homebrew/opt/cmake/share/cmake/Modules/FetchContent.cmake:2468:EVAL:1 (tr
ap_fetchcontent_provider)
  /opt/homebrew/opt/cmake/share/cmake/Modules/FetchContent.cmake:2468 (cmake_lan
guage)
  /opt/homebrew/opt/cmake/share/cmake/Modules/FetchContent.cmake:2314 (__FetchCo
ntent_MakeAvailable_eval_code)
  third-party/cpptrace/CMakeLists.txt:331 (FetchContent_MakeAvailable)
  ```

## Steps to Reproduce:

Brew version: `Homebrew 4.4.26-73-gccd6d14`

1. `brew install jank-lang/jank/jank`

or

1. `brew tap jank-lang/jank`
2. `brew install jank`

## Testing:

Tested with `brew install --build-from-source jank.rb` and `brew test jank`

Thanks for taking a look!