### PR TITLE
change LLVM 19 references to 21

### DIFF
--- a/Formula/jank.rb
+++ b/Formula/jank.rb
@@ -16,11 +16,11 @@ class Jank < Formula
   depends_on "openssl"
 
   def install
-    ENV.prepend_path "PATH", Formula["llvm@19"].opt_bin
+    ENV.prepend_path "PATH", Formula["llvm@21"].opt_bin
 
-    ENV.append "LDFLAGS", "-Wl,-rpath,#{Formula["llvm@19"].opt_lib}"
+    ENV.append "LDFLAGS", "-Wl,-rpath,#{Formula["llvm@21"].opt_lib}"
 
-    ENV.append "CPPFLAGS", "-L#{Formula["llvm@19"].opt_include}"
+    ENV.append "CPPFLAGS", "-L#{Formula["llvm@21"].opt_include}"
     ENV.append "CPPFLAGS", "-fno-sized-deallocation"
 
     jank_install_dir = OS.linux? ? libexec : bin
@@ -31,8 +31,8 @@ class Jank < Formula
     if OS.mac?
       ENV["SDKROOT"] = MacOS.sdk_path
     else
-      ENV["CC"] = Formula["llvm@19"].opt_bin/"clang"
-      ENV["CXX"] = Formula["llvm@19"].opt_bin/"clang++"
+      ENV["CC"] = Formula["llvm@21"].opt_bin/"clang"
+      ENV["CXX"] = Formula["llvm@21"].opt_bin/"clang++"
     end
 
     cd "compiler+runtime"


### PR DESCRIPTION
Pursuant to slack thread <https://clojurians.slack.com/archives/C03SRH97FDK/p1759594844493429>

I did this same find/replace locally, and that got me past the "missing clang" error.