### PR TITLE
fix: Add zlib dependency to match Debian

### DIFF
--- a/Formula/jank-git.rb
+++ b/Formula/jank-git.rb
@@ -13,6 +13,7 @@ class Jank < Formula
   depends_on "libzip"
   depends_on "llvm@21"
   depends_on "openssl"
+  depends_on "zlib"
 
   skip_clean "bin/jank"
 

--- a/Formula/jank.rb
+++ b/Formula/jank.rb
@@ -8,6 +8,7 @@ class Jank < Formula
   depends_on "boost"
   depends_on "libzip"
   depends_on "openssl"
+  depends_on "zlib"
 
   skip_clean "bin/jank"
 


### PR DESCRIPTION
Add zlib dependency to match the Debian dependency added for compiling with leiningen on a jank project.